### PR TITLE
CVE-2025-41234: Spring: RFD Attack via “Content-Disposition” Header Sourced from Request

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+++ b/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ public final class ContentDisposition {
 		for (int i=33; i<= 126; i++) {
 			PRINTABLE.set(i);
 		}
+		PRINTABLE.set(34, false); // "
 		PRINTABLE.set(61, false); // =
 		PRINTABLE.set(63, false); // ?
 		PRINTABLE.set(95, false); // _

--- a/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.springframework.http.ContentDisposition.parse;
 
 /**
- * Unit tests for {@link ContentDisposition}.
+ * Tests for {@link ContentDisposition}.
  *
  * @author Sebastien Deleuze
  * @author Rossen Stoyanchev
@@ -303,6 +303,13 @@ class ContentDispositionTests {
 		tester.accept("foo.txt\\", "foo.txt\\\\");
 		tester.accept("foo.txt\\\\", "foo.txt\\\\\\\\");
 		tester.accept("foo.txt\\\\\\", "foo.txt\\\\\\\\\\\\");
+	}
+
+	@Test
+	void formatWithUtf8FilenameWithQuotes() {
+		String filename = "\"中文.txt";
+		assertThat(ContentDisposition.formData().filename(filename, StandardCharsets.UTF_8).build().toString())
+				.isEqualTo("form-data; filename=\"=?UTF-8?Q?=22=E4=B8=AD=E6=96=87.txt?=\"; filename*=UTF-8''%22%E4%B8%AD%E6%96%87.txt");
 	}
 
 	@Test


### PR DESCRIPTION
CVE-2025-41234